### PR TITLE
Temporarily pin node to 14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
   # Define one or more jobs which will utilize your orb's commands and parameters to validate your changes.
   integration-test-commands:
     docker:
-      - image: cimg/node:lts
+      - image: cimg/node:14.18
     steps:
       - haikunator/install
       - haikunator/generate:

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -4,6 +4,6 @@ docker:
   - image: 'cimg/node:<<parameters.tag>>'
 parameters:
   tag:
-    default: lts
+    default: 14.18
     description: A CircleCI Node.js image version
     type: string


### PR DESCRIPTION
#### Context

Looks like it's possible this orb doesn't work on node 16; pinning to node 14 will hopefully fix!

(I literally just found and replaced all instances of `lts` with `14.18`. Not sure if only one needed to get changed; we can revert both when necessary)