### PR TITLE
remove `npx` usage [semver:patch]

### DIFF
--- a/src/commands/generate.yml
+++ b/src/commands/generate.yml
@@ -38,7 +38,7 @@ steps:
   - run:
       name: Generate haikunator ID
       command: |-
-        id="$(npx haikunator \
+        id="$(haikunator \
           <<# parameters.adjectives >>--adjectives="<< parameters.adjectives >>"<</ parameters.adjectives >> \
           <<# parameters.nouns >>--nouns="<< parameters.nouns >>"<</ parameters.nouns >> \
           <<# parameters.seed >>--seed="<< parameters.seed >>"<</ parameters.seed >> \


### PR DESCRIPTION
In Node 16, `npx@8` causes the following error when called here:

```
$ npx haikunator
npm ERR! could not determine executable to run

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/circleci/.npm/_logs/2021-10-29T18_06_03_785Z-debug.log
circleci@8d7932175cbc:~$ npx exec -h
npm ERR! could not determine executable to run

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/circleci/.npm/_logs/2021-10-29T18_06_31_402Z-debug.log
```

Node 14 comes with `npx@6`. Because the package is installed globally to a directory in the `$PATH`, there is no need for `npx`:

https://github.com/TakeScoop/haikunator-orb/blob/master/src/commands/install.yml#L15

Closes #7